### PR TITLE
fix(scripts): generation of multi-color bmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ The micro-controller I am using is an ESP32.
 
 ## Development
 
+```bash
+python style.py
+```
+

--- a/image_processing/generate_bitmap_h.py
+++ b/image_processing/generate_bitmap_h.py
@@ -1,4 +1,6 @@
+from typing import List
 from PIL import Image
+import inquirer
 import numpy as np
 from pillow_heif import register_heif_opener
 import glob
@@ -6,49 +8,98 @@ import glob
 # Enables opening HEIF files in default supported by PIL
 register_heif_opener()
 
-def generate_bitmap_h (input_dir='output_images', output_file='custom_bitmaps.h') -> None:
-  """Converts `.bmp` images in the `input_dir` to group of uint_8 arrays in a header file with the name `output_file`
 
-  Args:
-      input_dir (str, optional): The directory containing the `.bmp` files. Defaults to 'output_images'.
-      output_file (str, optional): The name of the file to place the generated C code. Defaults to 'custom_bitmaps.h'.
-  """
-  bitmaps = []
-  for filepath in glob.glob(f"{input_dir}/*"):
-    # Ignore the README file in the input directory
-    if filepath.endswith("README.md"):
-      break
-    try:
-      print(f"Processing: {filepath}")
-      # Read the image, giving a single bit to each pixel
-      bitmap_image = Image.open(filepath).convert('1')
-      # group the bitmap every eight bits
-      image_data = np.array(bitmap_image.getdata()).reshape(-1, 8) // 255
-      # convert each row to a string of eight 0s and 1s
-      image = np.array([''.join(row) for row in image_data.astype(str)])
-      # read each binary string as a binary number (0 to 15)
-      image = np.array([int(row, 2) for row in image])
-      # convert the binary number into a hex number
-      image = np.array([hex(row) for row in image])
-      # For formatting, each row of the image is 30 bytes
-      image = image.reshape(-1, 50)
-      # convert each row to a string
-      bitmap_arr_rows_str = np.array([','.join(row) for row in image.astype(str)])
-      # concatenate the rows
-      bitmap_arr_str = ",\n".join(bitmap_arr_rows_str)
-      bitmap_var = "const unsigned char bitmap_" + str(len(bitmaps)) + "[] PROGMEM = {\n" + bitmap_arr_str + "};\n"
-      bitmaps.append(bitmap_var)
-    except Exception as e:
-      print("Failed to process:", filepath)
-      print(e)
-  generated_bitmaps = ", ".join(f"bitmap_{i}" for i in range(len(bitmaps)))
-  file_imports = "#define _GxBitmaps400x300_H_\n\n#include <pgmspace.h>\n\n"
-  bitmaps_list = "const unsigned char *bitmaps[] = {" + generated_bitmaps + "};"
-  file_contents = file_imports + "\n".join(bitmaps) + "\n" + bitmaps_list
+def generate_bitmap_h(bmp_imgs: List[Image.Image]) -> str:
+    """Converts the list of BMP images to the contents of a bitmap header file
 
-  # write to file
-  with open(output_file, "w") as file:
-    file.write(file_contents)
+    Args:
+        input_dir (str, optional): The directory containing the `.bmp` files.
+        Defaults to 'output_images'.
+        output_file (str, optional): The name of the generated C code file.
+        Defaults to 'custom_bitmaps.h'.
+    """
+    # A list of strings, each a variable defn for a bitmap in C
+    bitmaps: List[str] = []
+    for bitmap_image in bmp_imgs:
+        # Read the image, giving a single bit to each pixel
+        bitmap_image = bitmap_image.convert("L")
+        palette = sorted(list(set(bitmap_image.getdata())))
+        base = int(np.ceil(np.log2(len(palette))))
+        palette_binary = [(bin(i)[2:]).rjust(base, "0") for i in range(len(palette))]
+        # group the bitmap every eight bits
+        image_data = np.array(bitmap_image.getdata()).astype(str)
+        # convert
+        for b, c in zip(palette_binary, palette):
+            image_data[image_data == str(c)] = b
+        image_data = np.array(list("".join(image_data.astype(str))))
+        image_data = image_data.reshape((-1, 8))
+        # convert each row to a string of eight 0s and 1s
+        image = np.array(["".join(row) for row in image_data.astype(str)])
+        # read each binary string as a binary number (0 to 15)
+        image = np.array([int(row, 2) for row in image])
+        # convert the binary number into a hex number
+        image = np.array([hex(row) for row in image])
+        # For formatting, each row of the image is 30 bytes
+        image = image.reshape(-1, 50)
+        # convert each row to a string
+        bitmap_arr_rows_str = np.array([",".join(row) for row in image.astype(str)])
+        # concatenate the rows
+        bitmap_arr_str = ",\n".join(bitmap_arr_rows_str)
+        bitmap_var = (
+            "const unsigned char bitmap_"
+            + str(len(bitmaps))
+            + "[] PROGMEM = {\n"
+            + bitmap_arr_str
+            + "};\n"
+        )
+        bitmaps.append(bitmap_var)
 
-if __name__ == "__main__": 
-  generate_bitmap_h()
+    generated_bitmaps = ", ".join(f"bitmap_{i}" for i in range(len(bitmaps)))
+    file_imports = "#define _GxBitmaps400x300_H_\n\n#include <pgmspace.h>\n\n"
+    bitmaps_list = "const unsigned char *bitmaps[] = {" + generated_bitmaps + "};"
+    file_contents = file_imports + "\n".join(bitmaps) + "\n" + bitmaps_list
+
+    return file_contents
+
+
+if __name__ == "__main__":
+
+    answers = inquirer.prompt(
+        [
+            inquirer.Path(
+                "input_dir",
+                message="Folder with .bmp files:",
+                exists=True,
+                path_type=inquirer.Path.DIRECTORY,
+            ),
+            inquirer.Text(
+                "output_file",
+                "custom_bitmaps.h",
+                message="Name of file:",
+            ),
+        ]
+    )
+    if answers is None:
+        exit()
+    input_dir = answers["input_dir"].rstrip("/\\")
+    output_file: str = answers["output_file"]
+    output_file = output_file if output_file.endswith(".h") else output_file + ".h"
+    bmp_files = [Image.open(filepath) for filepath in glob.glob(f"{input_dir}/*")]
+
+    images = []
+    for filepath in glob.glob(f"{input_dir}/*"):
+        # Ignore the README file in the input directory
+        if filepath.endswith("README.md"):
+            break
+        try:
+            # Read the image, giving a single bit to each pixel
+            bitmap_image = Image.open(filepath)
+            images.append(bitmap_image)
+        except Exception as e:
+            print("Failed to load:", filepath)
+            print(e)
+
+    file_contents = generate_bitmap_h(images)
+    # write to file
+    with open(output_file, "w") as file:
+        file.write(file_contents)

--- a/image_processing/generate_bmp_files.py
+++ b/image_processing/generate_bmp_files.py
@@ -1,4 +1,4 @@
-import numpy as np
+from typing import List, Tuple
 from PIL import Image, ImageOps
 from pillow_heif import register_heif_opener
 import glob
@@ -6,34 +6,61 @@ import glob
 # Enables opening HEIF files in default supported by PIL
 register_heif_opener()
 
-def generate_bmp_files(input_dir="input_images", output_dir="output_images", dimentions: tuple[int, int]=(400,300)) -> None:
-  """
-  Reads all of the images in the `input_images` directory, resizes them, dithers, and saves the BMP files
-  to the `output_dir. Supports most image types, including PNG, JPG, and HEIF images.
 
-  Args:
-      input_dir (str, optional): The folder to read image files. Defaults to "input_images".
-      output_dir (str, optional): The folder to place `.bmp` files. Defaults to "output_images".
-      dimentions (tuple[int, int], optional): The target (width, height) of the image. Defaults to (400,300).
-  """
-  for filepath in glob.glob(f"{input_dir}/*"):
-    # Ignore the README file in the input directory
-    if filepath.endswith("README.md"):
-      break
-    filename = "".join(filepath[len(input_dir)+1:].split('.')[:-1])
-    print(f"Processing: {filepath}")
-    try:
-      im_frame = Image.open(filepath)
-      # JPEGs can have EXIF Orientation Data sometimes
-      im_frame = ImageOps.exif_transpose(im_frame)
-      # Resize the image
-      im_frame = im_frame.resize(dimentions)
-      # Converts to 1-bit repr per pixel. Uses Floyd-Steinberg dithering
-      im_frame = im_frame.convert("1")
-      im_frame.save(f"{output_dir}/{filename}.bmp")
-    except Exception as e:
-      print("Failed to process:", filepath)
-      print(e)
+def load_images(
+    input_directory: str, dimensions: Tuple[int, int] = (400, 300)
+) -> List[Tuple[str, Image.Image]]:
+    """
+    Loads all of the images in the input directory and returns them as a list
+    of PIL Image objects.
+
+    If an image fails to load, it is printed to the console and omitted from
+    the returned list
+    """
+    images = []
+    input_dir_len = len(input_directory) + 1
+    for filepath in glob.glob(f"{input_directory}/*"):
+        filename = "".join(filepath[input_dir_len:].split(".")[:-1])
+        # Ignore the README file in the input directory
+        if filepath.endswith("README.md"):
+            break
+        try:
+            im_frame = Image.open(filepath)
+            # JPEGs can have EXIF Orientation Data sometimes
+            ImageOps.exif_transpose(im_frame, in_place=True)
+            im_frame = im_frame.resize(dimensions)
+            images.append((filename, im_frame))
+        except Exception as e:
+            print("Failed to process:", filepath)
+            print(e)
+    return images
+
+
+def convert_to_bmp(source_image: Image.Image, colors: int = 2) -> Image.Image:
+    """
+    Converts the source image to a BMP image with the specified number of
+    colors. The default is 2 colors.
+    """
+    im_frame = source_image.copy()
+    # Converts to 1-bit per pixel. Uses Floyd-Steinberg dithering
+    if colors == 2:
+        im_frame = im_frame.convert("1")
+    # Converts to multiple bits per pixel. Uses Floyd-Steinberg dithering
+    else:
+        im_frame = im_frame.quantize(
+            colors,
+            palette=im_frame.convert("L").quantize(colors),
+            dither=Image.Dither.FLOYDSTEINBERG,
+        )
+    return im_frame
+
 
 if __name__ == "__main__":
-  generate_bmp_files()
+    input_dir = "input_images"
+    output_dir = "output_images"
+
+    images = load_images(input_dir, dimensions=(400, 300))
+
+    for filename, image_data in images:
+        bmp_image = convert_to_bmp(image_data)
+        bmp_image.save(f"{output_dir}/{filename}.bmp")

--- a/image_processing/main.py
+++ b/image_processing/main.py
@@ -1,78 +1,121 @@
+from typing import Literal
 import inquirer
-
 from generate_bitmap_h import generate_bitmap_h
-from generate_bmp_files import generate_bmp_files
+from generate_bmp_files import convert_to_bmp, load_images
+from PIL import Image
 
 HEADER_OPTION = "A Header File (no SD card)"
 BMP_DIR_OPTION = "BMP Files (for SD Card)"
 
-def positive_integer(answers, text: str):
-  """Validates that the string is a positive integer"""
-  try:
-    if int(text) <= 0 or int(text) != float(text):
-      raise inquirer.errors.ValidationError("", reason="Please enter a positive integer.")
-  except Exception as e:
-    raise inquirer.errors.ValidationError("", reason="Please enter a number")
-  return True
+
+def positive_integer(_: dict[str, str], text: str) -> Literal[True]:
+    """Validates that the string is a positive integer"""
+    try:
+        if int(text) <= 0 or int(text) != float(text):
+            raise inquirer.errors.ValidationError(
+                "", reason="Please enter a positive integer."
+            )
+    except Exception:
+        raise inquirer.errors.ValidationError("", reason="Please enter a number")
+    return True
+
+
+# An enum for each of the inquirer fields
+class Field:
+    WIDTH = "width"
+    HEIGHT = "height"
+    COLORS = "colors"
+    INPUT_DIR = "input_dir"
+    OUTPUT = "output"
+    OUTPUT_DIR = "output_dir"
+    HEADER_FILE_NAME = "header_file_name"
 
 
 def perform_script() -> None:
-  answers = inquirer.prompt([
-    inquirer.List(
-      "output", 
-      message='Save images as:', 
-      choices=[BMP_DIR_OPTION, HEADER_OPTION], 
-      default=HEADER_OPTION
-    ),
-    inquirer.Path(
-      "input_dir", 
-      message="Directory with images?", 
-      default="input_images"
-    ),
-    inquirer.Path(
-      "output_dir", 
-      message="Directory to put BMP files?", 
-      default="output_images"
-    ),
-    inquirer.Text(
-      "width", 
-      message="Width of the display", 
-      default="400", 
-      validate=positive_integer
-    ),
-    inquirer.Text(
-      "height", 
-      message="Height of the display", 
-      default="300", 
-      validate=positive_integer
-    ),
-  ])
-  # Keyboard interrupt
-  if answers is None:
-     return
-  output_dir = answers['output_dir']
-  generate_bmp_files(
-    input_dir=answers['input_dir'], 
-    output_dir=output_dir, 
-    dimentions=[
-      int(answers['width']), 
-      int(answers['height'])
-    ]
-  )
+    answers = inquirer.prompt(
+        [
+            inquirer.Text(
+                Field.WIDTH,
+                message="Width of the display",
+                default="400",
+                validate=positive_integer,
+            ),
+            inquirer.Text(
+                Field.HEIGHT,
+                message="Height of the display",
+                default="300",
+                validate=positive_integer,
+            ),
+            inquirer.Text(
+                Field.COLORS,
+                message="Number of colors (binary is 2)",
+                default="2",
+                validate=positive_integer,
+            ),
+            inquirer.Path(
+                Field.INPUT_DIR,
+                message="Directory with images?",
+                default="input_images",
+            ),
+            inquirer.List(
+                Field.OUTPUT,
+                message="Save images as:",
+                choices=[BMP_DIR_OPTION, HEADER_OPTION],
+                default=HEADER_OPTION,
+            ),
+        ]
+    )
+    if answers is None:
+        return
 
-  if answers["output"] == HEADER_OPTION:
-    answers = inquirer.prompt([
-      inquirer.Text(
-        "header_file_name",
-        message="Name for the Header File",
-        default="custom_bitmaps.h"
-      )
-    ])
-    if answers is not None:
-      generate_bitmap_h(
-        input_dir=output_dir,
-        output_file=answers["header_file_name"]
-      )
+    def load_bmp_images() -> list[tuple[str, Image.Image]]:
+        raw_image_data = load_images(
+            answers[Field.INPUT_DIR],
+            dimensions=(int(answers[Field.WIDTH]), int(answers[Field.HEIGHT])),
+        )
+        bmp_image_data = [
+            (filename, convert_to_bmp(image, colors=int(answers[Field.COLORS])))
+            for filename, image in raw_image_data
+        ]
+        return bmp_image_data
+
+    # Save the images as a directory of BMP Images
+    if answers[Field.OUTPUT] is BMP_DIR_OPTION:
+        followup_answers = inquirer.prompt(
+            [
+                inquirer.Path(
+                    Field.OUTPUT_DIR,
+                    message="Directory to put BMP files?",
+                    default="output_images",
+                )
+            ]
+        )
+        if followup_answers is None:
+            return
+        bmp_image_data = load_bmp_images()
+        output_dir = followup_answers[Field.OUTPUT_DIR]
+        for filename, image in bmp_image_data:
+            image.save(f"{output_dir}/{filename}.bmp")
+
+    # Save the images as a single header file of bitmap arrays
+    elif answers[Field.OUTPUT] is HEADER_OPTION:
+        followup_answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    Field.HEADER_FILE_NAME,
+                    message="Name for the Header File",
+                    default="custom_bitmaps.h",
+                )
+            ]
+        )
+        if followup_answers is None:
+            return
+        bmp_image_data = load_bmp_images()
+        output_file = followup_answers[Field.HEADER_FILE_NAME]
+        file_contents = generate_bitmap_h([image for _, image in bmp_image_data])
+        with open(output_file, "w") as file:
+            file.write(file_contents)
+
 
 if __name__ == "__main__":
-   perform_script()
+    perform_script()

--- a/image_processing/setup.cfg
+++ b/image_processing/setup.cfg
@@ -1,0 +1,21 @@
+[flake8]
+# Recommend matching the black line length (default 88),
+# rather than using the flake8 default of 79:
+max-line-length = 88
+exclude = venv
+ignore = E111, W503
+
+[tool.black]
+exclude = venv
+
+[mypy]
+strict = True
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-inquirer.*]
+ignore_missing_imports = True
+
+[mypy-pillow_heif.*]
+ignore_missing_imports = True

--- a/image_processing/style.py
+++ b/image_processing/style.py
@@ -1,0 +1,6 @@
+import subprocess
+
+if __name__ == "__main__":
+    subprocess.run(["black", "."])
+    subprocess.run(["flake8", "."])
+    subprocess.run(["mypy", "."])


### PR DESCRIPTION
Improved style convention of the Python scripts using `black`, `mypy`, and `fflake8`. To do so, run:
```
python style.py
```

Fixed the generation of bitmaps with multiple grayscales. 

Todo: generate colored bitmaps with red and yellow.