### PR TITLE
feat(scripts): generate .bin files for reading from SD Card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,9 +162,11 @@ cython_debug/
 
 # Ignore all files in the input and output folders except the README
 /image_processing/input_images/*
-!/image_processing/input_images/README.md
+!/image_processing/input_images/.README.md
 /image_processing/output_images/*
-!/image_processing/output_images/README.md
+!/image_processing/output_images/.README.md
+/image_processing/preview_images/*
+!/image_processing/preview_images/.README.md
 image_processing/custom_bitmaps.h
 
 custom_bitmaps.h

--- a/image_processing/generate_bin_files.py
+++ b/image_processing/generate_bin_files.py
@@ -1,0 +1,96 @@
+import math
+from PIL import Image, ImageOps
+from typing import List, Tuple
+from tqdm import tqdm
+import glob
+
+
+def load_images(
+    input_directory: str, dimensions: Tuple[int, int] = (400, 300)
+) -> List[Tuple[str, Image.Image]]:
+    """
+    Loads all of the images in the input directory and returns them as a list
+    of PIL Image objects.
+
+    If an image fails to load, it is printed to the console and omitted from
+    the returned list
+    """
+    images = []
+    input_dir_len = len(input_directory) + 1
+    for filepath in tqdm(glob.glob(f"{input_directory}/*"), desc="Reading Images"):
+        filename = "".join(filepath[input_dir_len:].split(".")[:-1])
+        # Ignore the README file in the input directory
+        if filepath.endswith("README.md"):
+            continue
+        try:
+            im_frame = Image.open(filepath)
+            # JPEGs can have EXIF Orientation Data sometimes
+            ImageOps.exif_transpose(im_frame, in_place=True)
+            im_frame = im_frame.resize(dimensions)
+            images.append((filename, im_frame))
+        except Exception as e:
+            print("Failed to process:", filepath)
+            print(e)
+    return images
+
+
+def convert_to_bin(source_image: Image.Image, colors: int = 4) -> bytes:
+    # Invert the image
+    inverted_image = ImageOps.invert(source_image).quantize(
+        4,
+        palette=ImageOps.invert(source_image).convert("L").quantize(4),
+        dither=Image.Dither.FLOYDSTEINBERG,
+    )
+
+    image_bytes = inverted_image.tobytes()
+    bpp = math.ceil(math.log2(colors))
+
+    result = bytearray()
+    buffer = 0
+    buffer_length = 0
+
+    for byte in image_bytes:
+        # Keep only the last bpp bits
+        last_bits = byte & 2**bpp - 1
+        # Add the n bits to the buffer
+        buffer = (buffer << bpp) | last_bits
+        buffer_length += bpp
+        # If the buffer has a full byte, add it to the result
+        if buffer_length >= 8:
+            result.append((buffer >> (buffer_length - 8)) & 0xFF)
+            buffer_length -= 8
+
+    # If there are remaining bits in the buffer, append them as a final byte
+    if buffer_length > 0:
+        result.append((buffer << (8 - buffer_length)) & 0xFF)
+
+    return bytes(result)
+
+
+def save_to_binary_file(byte_string: bytes, filename: str) -> None:
+    try:
+        with open(filename, "wb") as binary_file:
+            binary_file.write(byte_string)
+    except IOError as e:
+        print(f"An error occurred while writing to the file: {e}")
+
+
+if __name__ == "__main__":
+    images = load_images("input_images", (400, 300))
+    test_image = images[0][1]
+
+    im_bytes = convert_to_bin(test_image, colors=4)
+
+    result = bytearray()
+    bytes_per_shade = int(100 * 300 / 4)
+
+    for i in range(bytes_per_shade):
+        result.append(0b00000000)
+    for i in range(bytes_per_shade):
+        result.append(0b01010101)
+    for i in range(bytes_per_shade):
+        result.append(0b10101010)
+    for i in range(bytes_per_shade):
+        result.append(0b11111111)
+
+    save_to_binary_file(result, "./test2.bin")

--- a/image_processing/input_images/.README.md
+++ b/image_processing/input_images/.README.md
@@ -1,0 +1,5 @@
+# Instructions
+
+- Put any `.jpg`, `.png`, and `.HEIC` files in this folder.
+- For best results, resize your photos to be the same aspect ratio as the device
+- The program will distort images to be the right size.

--- a/image_processing/input_images/README.md
+++ b/image_processing/input_images/README.md
@@ -1,5 +1,0 @@
-Put any `.jpg` and `.png` files in this folder.
-
-Running the script will generate dithered bitmap (`.bmp`) files in the output folder.
-
-Any files that are not already a 4:3 ratio will prompt you to crop the images.

--- a/image_processing/main.py
+++ b/image_processing/main.py
@@ -1,12 +1,14 @@
 from typing import Literal
 import inquirer
 from tqdm import tqdm
+from generate_bin_files import convert_to_bin, save_to_binary_file
 from generate_bitmap_h import generate_bitmap_h
 from generate_bmp_files import convert_to_bmp, load_images
-from PIL import Image
+
 
 HEADER_OPTION = "A Header File (no SD card)"
 BMP_DIR_OPTION = "BMP Files (for SD Card)"
+BIN_DIR_OPTION = "BIN Files (for SD Card)"
 
 
 def positive_integer(_: dict[str, str], text: str) -> Literal[True]:
@@ -29,6 +31,8 @@ class Field:
     INPUT_DIR = "input_dir"
     OUTPUT = "output"
     OUTPUT_DIR = "output_dir"
+    SHOULD_GENERATE_PREVIEW = "should_gen_preview"
+    PREVIEW_DIR = "preview_dir"
     HEADER_FILE_NAME = "header_file_name"
 
 
@@ -61,24 +65,13 @@ def perform_script() -> None:
             inquirer.List(
                 Field.OUTPUT,
                 message="Save images as:",
-                choices=[BMP_DIR_OPTION, HEADER_OPTION],
-                default=HEADER_OPTION,
+                choices=[BIN_DIR_OPTION, BMP_DIR_OPTION, HEADER_OPTION],
+                default=BIN_DIR_OPTION,
             ),
         ]
     )
     if answers is None:
         return
-
-    def load_bmp_images() -> list[tuple[str, Image.Image]]:
-        raw_image_data = load_images(
-            answers[Field.INPUT_DIR],
-            dimensions=(int(answers[Field.WIDTH]), int(answers[Field.HEIGHT])),
-        )
-        bmp_image_data = [
-            (filename, convert_to_bmp(image, colors=int(answers[Field.COLORS])))
-            for filename, image in tqdm(raw_image_data, desc="Convert to BMP Files")
-        ]
-        return bmp_image_data
 
     # Save the images as a directory of BMP Images
     if answers[Field.OUTPUT] is BMP_DIR_OPTION:
@@ -88,15 +81,67 @@ def perform_script() -> None:
                     Field.OUTPUT_DIR,
                     message="Directory to put BMP files?",
                     default="output_images",
-                )
+                ),
             ]
         )
         if followup_answers is None:
             return
-        bmp_image_data = load_bmp_images()
+        # load the images from the directory
+        raw_image_data = load_images(
+            input_directory=answers[Field.INPUT_DIR],
+            dimensions=(int(answers[Field.WIDTH]), int(answers[Field.HEIGHT])),
+        )
+
         output_dir = followup_answers[Field.OUTPUT_DIR]
-        for filename, image in bmp_image_data:
-            image.save(f"{output_dir}/{filename}.bmp")
+        for filename, image in tqdm(raw_image_data, desc="Convert to BMP Files"):
+            # convert the images into the BMP format
+            bmp_data = convert_to_bmp(image, colors=int(answers[Field.COLORS]))
+            # save the BMP formatted images into the directory
+            bmp_data.save(f"{output_dir}/{filename}.bmp")
+
+    # Save the images as a directory of BMP Images
+    if answers[Field.OUTPUT] is BIN_DIR_OPTION:
+        followup_answers = inquirer.prompt(
+            [
+                inquirer.Path(
+                    Field.OUTPUT_DIR,
+                    message="Directory to put BIN files?",
+                    default="output_images",
+                ),
+                inquirer.Confirm(
+                    Field.SHOULD_GENERATE_PREVIEW,
+                    message="Generate BMP for previewing?",
+                    default=True,
+                ),
+                inquirer.Path(
+                    Field.PREVIEW_DIR,
+                    message="Directory to put BMP files?",
+                    default="preview_images",
+                    ignore=lambda answers: not answers[Field.SHOULD_GENERATE_PREVIEW],
+                ),
+            ]
+        )
+        if followup_answers is None:
+            return
+        # load the images from the directory
+        raw_image_data = load_images(
+            input_directory=answers[Field.INPUT_DIR],
+            dimensions=(int(answers[Field.WIDTH]), int(answers[Field.HEIGHT])),
+        )
+
+        output_dir = followup_answers[Field.OUTPUT_DIR]
+        preview_dir = followup_answers[Field.PREVIEW_DIR]
+        for filename, image in tqdm(raw_image_data, desc="Convert to BMP Files"):
+            # convert the images into the BMP format
+            bin_data = convert_to_bin(image, colors=int(answers[Field.COLORS]))
+            # save the BMP formatted images into the directory
+            save_to_binary_file(bin_data, f"{output_dir}/{filename}.bin")
+
+            # generate bin
+            if followup_answers[Field.SHOULD_GENERATE_PREVIEW]:
+                bmp_data = convert_to_bmp(image, colors=int(answers[Field.COLORS]))
+                # save the BMP formatted images into the directory
+                bmp_data.save(f"{preview_dir}/{filename}.bmp")
 
     # Save the images as a single header file of bitmap arrays
     elif answers[Field.OUTPUT] is HEADER_OPTION:
@@ -111,9 +156,18 @@ def perform_script() -> None:
         )
         if followup_answers is None:
             return
-        bmp_image_data = load_bmp_images()
+        # load the images from the directory
+        raw_image_data = load_images(
+            input_directory=answers[Field.INPUT_DIR],
+            dimensions=(int(answers[Field.WIDTH]), int(answers[Field.HEIGHT])),
+        )
+        bmp_images = [
+            convert_to_bmp(image, colors=int(answers[Field.COLORS]))
+            for _, image in tqdm(raw_image_data, desc="Convert to BMP Files")
+        ]
+
         output_file = followup_answers[Field.HEADER_FILE_NAME]
-        file_contents = generate_bitmap_h([image for _, image in bmp_image_data])
+        file_contents = generate_bitmap_h(bmp_images)
         with open(output_file, "w") as file:
             file.write(file_contents)
 

--- a/image_processing/output_images/.README.md
+++ b/image_processing/output_images/.README.md
@@ -1,0 +1,3 @@
+# Description
+
+Output images will be put here

--- a/image_processing/output_images/README.md
+++ b/image_processing/output_images/README.md
@@ -1,1 +1,0 @@
-Output images will be put here

--- a/image_processing/preview_images/.README.md
+++ b/image_processing/preview_images/.README.md
@@ -1,0 +1,3 @@
+# Description
+
+When generating BIN files, you will be prompted with whether you want to also generate BMP files to preview the result conveniently.


### PR DESCRIPTION
Turns out, bmp files assign 8 bits per pixel anyways, even if I only wanted 4 grayscale colors. I use bin files instead, both because I have better control over the size of the file, but also it's more convenient when reading from SD Card